### PR TITLE
Implement Jacobian coordinates for ECC

### DIFF
--- a/include/ecc.hpp
+++ b/include/ecc.hpp
@@ -88,16 +88,23 @@ struct CurveParams {
 CurveParams get_curve_params(CurveType type);
 
 // ============================================================================
-// PUNTO EN CURVA ELiPTICA
+// PUNTO EN CURVA ELIPTICA (COORDENADAS AFINES)
 // ============================================================================
 
 /**
- * @brief Representa un punto en una curva eli­ptica
+ * @brief Representa un punto en coordenadas afines (x, y) 
  * 
- * Soporta:
- * - Punto en el infinito (punto de identidad)
- * - Coordenadas afines (x, y)
- * - Coordenadas proyectivas (X, Y, Z) para optimizacion (futuro)
+ * Coordenadas afines: representacion directa del punto como (x, y) en Fp.
+ * Cada operacion de suma/doblado requiere una inversion modular (costosa).
+ * 
+ * Ventajas:
+ * - Representacion natural y facil de verificar
+ * - Cada punto intermedio se puede comprobar con is_on_curve()
+ * - Ideal para debugging y comprension educativa
+ * 
+ * Desventajas:
+ * - La inversion modular en cada operacion es costosa (~100x una multiplicacion)
+ * - Para multiplicacion escalar con ~256 pasos, el coste se acumula
  */
 class ECPoint {
 private:
@@ -147,7 +154,67 @@ public:
 };
 
 // ============================================================================
-// OPERACIONES EN CURVA ELiPTICA
+// PUNTO EN COORDENADAS JACOBIANAS
+// ============================================================================
+ 
+/**
+ * @brief Representa un punto en coordenadas Jacobianas (X, Y, Z)
+ * 
+ * Relacion con coordenadas afines:
+ *   (x, y) = (X/Z^2, Y/Z^3)
+ * 
+ * El punto en el infinito se representa como Z = 0.
+ * 
+ * Ventajas de coordenadas Jacobianas:
+ * - Eliminan la inversion modular durante suma y doblado
+ * - Solo se necesita UNA inversion al convertir de vuelta a afines
+ * - Para multiplicacion escalar de ~256 bits: ~255 inversiones eliminadas
+ * - Speedup tipico: 3-5x sobre coordenadas afines
+ * 
+ * Coste por operacion (M = multiplicacion, S = cuadrado, I = inversion):
+ * 
+ *   Operacion        | Afin          | Jacobiano
+ *   -----------------+---------------+----------
+ *   Doblado          | 1I + 2M + 2S  | 4M + 4S
+ *   Suma             | 1I + 2M + 1S  | 12M + 4S
+ *   Scalar mult 256b | ~384 I        | 1 I (al final)
+ * 
+ * Como I ~ 80-100 M en campos grandes, la diferencia es enorme.
+ * 
+ * Por que no usamos Jacobianas desde el principio:
+ * - Las coordenadas afines son mas intuitivas para aprender ECC
+ * - Cada resultado intermedio es verificable directamente (is_on_curve)
+ * - En Jacobianas, el mismo punto tiene infinitas representaciones
+ *   Ej: (x,y,1) == (4x, 8y, 2) == (9x, 27y, 3) ...
+ * - Depurar errores en Jacobiano es mucho mas dificil
+ * - El enfoque educativo: primero correccion, luego optimizacion
+ */
+class JacobianPoint {
+private:
+    BigInt X_;
+    BigInt Y_;
+    BigInt Z_;
+    const CurveParams* curve_;
+    
+public:
+    /** @brief Constructor para el punto en el infinito (Z = 0) */
+    JacobianPoint(const CurveParams* curve);
+    
+    /** @brief Constructor con coordenadas Jacobianas */
+    JacobianPoint(const BigInt& X, const BigInt& Y, const BigInt& Z,
+                  const CurveParams* curve);
+    
+    const BigInt& X() const { return X_; }
+    const BigInt& Y() const { return Y_; }
+    const BigInt& Z() const { return Z_; }
+    bool is_infinity() const { return Z_ == 0; }
+    const CurveParams* curve() const { return curve_; }
+    
+    void print() const;
+};
+
+// ============================================================================
+// OPERACIONES EN COORDENADAS AFINES
 // ============================================================================
 
 /**
@@ -196,6 +263,25 @@ ECPoint ec_negate(const ECPoint& P);
 ECPoint ec_scalar_mult(const BigInt& k, const ECPoint& P);
 
 // ============================================================================
+// OPERACIONES EN COORDENADAS JACOBIANAS
+// ============================================================================
+ 
+/** @brief Convierte punto afin a Jacobiano: (x, y) -> (x, y, 1) */
+JacobianPoint to_jacobian(const ECPoint& P);
+ 
+/** @brief Convierte Jacobiano a afin: (X, Y, Z) -> (X/Z^2, Y/Z^3) */
+ECPoint to_affine(const JacobianPoint& J);
+ 
+/** @brief Suma en Jacobianas. Coste: 12M + 4S, 0 inversiones */
+JacobianPoint jacobian_add(const JacobianPoint& P, const JacobianPoint& Q);
+ 
+/** @brief Doblado en Jacobianas. Coste: 4M + 4S, 0 inversiones */
+JacobianPoint jacobian_double(const JacobianPoint& P);
+ 
+/** @brief Multiplicacion escalar via Jacobianas (convierte al final) */
+ECPoint ec_scalar_mult_jacobian(const BigInt& k, const ECPoint& P);
+
+// ============================================================================
 // CLAVES ECC
 // ============================================================================
 
@@ -225,7 +311,7 @@ struct ECKeyPair {
  * @param rng Generador de numeros aleatorios
  * @return Par de claves
  */
-ECKeyPair generate_keypair(const CurveParams& curve, RNG& rng);
+ECKeyPair generate_keypair(const CurveParams& curve, RNG& rng, bool use_jacobian = false);
 
 // ============================================================================
 // DIFFIE-HELLMAN EN CURVAS ELIPTICAS (ECDH)
@@ -245,7 +331,8 @@ ECKeyPair generate_keypair(const CurveParams& curve, RNG& rng);
  * @return Punto compartido (usar x como secreto)
  */
 ECPoint ecdh_shared_secret(const BigInt& private_key, 
-                           const ECPoint& public_key);
+                           const ECPoint& public_key,
+                           bool use_jacobian = false);
 
 /**
  * @brief Deriva clave simetrica del secreto ECDH
@@ -304,7 +391,8 @@ struct ECDSASignature {
 ECDSASignature ecdsa_sign(const std::string& message,
                           const BigInt& private_key,
                           const CurveParams& curve,
-                          RNG& rng);
+                          RNG& rng,
+                          bool use_jacobian = false);
 
 /**
  * @brief Firma un hash (BigInt) directamente usando ECDSA
@@ -318,7 +406,8 @@ ECDSASignature ecdsa_sign(const std::string& message,
 ECDSASignature ecdsa_sign_hash(const BigInt& hash_value,
                                const BigInt& private_key,
                                const CurveParams& curve,
-                               RNG& rng);
+                               RNG& rng,
+                               bool use_jacobian = false);
 
 /**
  * @brief Verifica una firma ECDSA
@@ -342,7 +431,8 @@ ECDSASignature ecdsa_sign_hash(const BigInt& hash_value,
 bool ecdsa_verify(const std::string& message,
                   const ECDSASignature& signature,
                   const ECPoint& public_key,
-                  const CurveParams& curve);
+                  const CurveParams& curve,
+                  bool use_jacobian = false);
 
 /**
  * @brief Verifica una firma ECDSA a partir de un hash precalculado
@@ -350,7 +440,8 @@ bool ecdsa_verify(const std::string& message,
 bool ecdsa_verify_hash(const BigInt& hash_value,
                        const ECDSASignature& signature,
                        const ECPoint& public_key,
-                       const CurveParams& curve);
+                       const CurveParams& curve,
+                       bool use_jacobian = false);
 
 /**
  * @brief Trunca un hash al tamaño del orden de la curva

--- a/src/ecc.cpp
+++ b/src/ecc.cpp
@@ -1,8 +1,9 @@
 // ecc.cpp
-// ImplementaciÃ³n de Elliptic Curve Cryptography (ECC)
+// Implementacion de Elliptic Curve Cryptography (ECC)
+// Coordenadas afines + Jacobianas para curvas sobre campos primos
 // 
 // Autor: Leon Elliott Fuller
-// Fecha: 2026-01-04
+// Fecha: 2026-03-02
 
 #include "ecc.hpp"
 #include "sha256.hpp"
@@ -13,24 +14,16 @@
 namespace crypto {
 
 // ============================================================================
-// PARÃMETROS DE CURVAS ESTÃNDAR
+// PARAMETROS DE CURVAS ESTANDAR
 // ============================================================================
 
-/**
- * @brief Obtiene parÃ¡metros de curvas elÃ­pticas estÃ¡ndar
- * 
- * Fuentes:
- * - NIST P-256: FIPS 186-4
- * - NIST P-384: FIPS 186-4
- * - secp256k1: SEC 2
- */
 CurveParams get_curve_params(CurveType type) {
     CurveParams params;
     
     switch (type) {
         case CurveType::NIST_P256: {
             // NIST P-256 (secp256r1)
-            // Curva: yÂ² = xÂ³ - 3x + b (mod p)
+            // Curva: y^2 = x^3 - 3x + b (mod p)
             // Seguridad equivalente: RSA-3072
             
             params.name = "NIST P-256 (secp256r1)";
@@ -52,70 +45,43 @@ CurveParams get_curve_params(CurveType type) {
             // Order n (prime)
             conv(params.n, "115792089210356248762697446949407573529996955224135760342422259061068512044369");
             
-            // Cofactor
             params.h = to_ZZ(1);
-            
             break;
         }
         
         case CurveType::NIST_P384: {
             // NIST P-384
-            // Curva: yÂ² = xÂ³ - 3x + b (mod p)
             // Seguridad equivalente: RSA-7680
             
             params.name = "NIST P-384";
             params.bits = 384;
             
-            // p = 2^384 - 2^128 - 2^96 + 2^32 - 1
             conv(params.p, "39402006196394479212279040100143613805079739270465446667948293404245721771496870329047266088258938001861606973112319");
-            
-            // a = -3 (mod p)
             conv(params.a, "39402006196394479212279040100143613805079739270465446667948293404245721771496870329047266088258938001861606973112316");
-            
-            // b
             conv(params.b, "27580193559959705877849011840389048093056905856361568521428707301988689241309860865136260764883745107765439761230575");
-            
-            // Generator G
             conv(params.Gx, "26247035095799689268623156744566981891852923491109213387815615900925518854738050089022388053975719786650872476732087");
             conv(params.Gy, "8325710961489029985546751289520108179287853048861315594709205902480503199884419224438643760392947333078086511627871");
-            
-            // Order n
             conv(params.n, "39402006196394479212279040100143613805079739270465446667946905279627659399113263569398956308152294913554433653942643");
             
-            // Cofactor
             params.h = to_ZZ(1);
-            
             break;
         }
         
         case CurveType::SECP256K1: {
             // secp256k1 (Bitcoin/Ethereum)
-            // Curva: yÂ² = xÂ³ + 7 (mod p)
-            // a = 0, b = 7
-            // Seguridad equivalente: RSA-3072
+            // Curva: y^2 = x^3 + 7 (mod p), a = 0, b = 7
             
             params.name = "secp256k1 (Bitcoin)";
             params.bits = 256;
             
-            // p = 2^256 - 2^32 - 977
             conv(params.p, "115792089237316195423570985008687907853269984665640564039457584007908834671663");
-            
-            // a = 0
             params.a = to_ZZ(0);
-            
-            // b = 7
             params.b = to_ZZ(7);
-            
-            // Generator G
             conv(params.Gx, "55066263022277343669578718895168534326250603453777594175500187360389116729240");
             conv(params.Gy, "32670510020758816978083085130507043184471273380659243275938904335757337482424");
-            
-            // Order n
             conv(params.n, "115792089237316195423570985008687907852837564279074904382605163141518161494337");
             
-            // Cofactor
             params.h = to_ZZ(1);
-            
             break;
         }
         
@@ -130,12 +96,9 @@ CurveParams get_curve_params(CurveType type) {
 }
 
 bool CurveParams::validate() const {
-    // Validaciones bÃ¡sicas
-    
-    // 1. p debe ser primo (simplificado: solo verificamos que sea > 3)
     if (p <= 3) return false;
     
-    // 2. Verificar discriminante: 4aÂ³ + 27bÂ² â‰  0 (mod p)
+    // Verificar discriminante: 4a^3 + 27b^2 != 0 (mod p)
     ZZ_p::init(p);
     ZZ_p a_p = conv<ZZ_p>(a);
     ZZ_p b_p = conv<ZZ_p>(b);
@@ -143,7 +106,7 @@ bool CurveParams::validate() const {
     ZZ_p discriminant = 4 * power(a_p, 3) + 27 * power(b_p, 2);
     if (IsZero(discriminant)) return false;
     
-    // 3. Verificar que G estÃ¡ en la curva
+    // Verificar que G esta en la curva
     ZZ_p Gx_p = conv<ZZ_p>(Gx);
     ZZ_p Gy_p = conv<ZZ_p>(Gy);
     
@@ -152,10 +115,7 @@ bool CurveParams::validate() const {
     
     if (lhs != rhs) return false;
     
-    // 4. n debe ser > 0
     if (n <= 0) return false;
-    
-    // 5. h debe ser > 0
     if (h <= 0) return false;
     
     return true;
@@ -166,7 +126,7 @@ void CurveParams::print() const {
     std::cout << "CURVA: " << name << "\n";
     std::cout << std::string(70, '=') << "\n";
     std::cout << "Bits:       " << bits << "\n";
-    std::cout << "p (mÃ³dulo): " << p << "\n";
+    std::cout << "p (modulo): " << p << "\n";
     std::cout << "a:          " << a << "\n";
     std::cout << "b:          " << b << "\n";
     std::cout << "Gx:         " << Gx << "\n";
@@ -177,7 +137,7 @@ void CurveParams::print() const {
 }
 
 // ============================================================================
-// ECPoint - IMPLEMENTACIÃ“N
+// ECPoint (AFIN) - IMPLEMENTACION
 // ============================================================================
 
 ECPoint::ECPoint(const CurveParams* curve)
@@ -201,7 +161,7 @@ ECPoint::ECPoint(const BigInt& x, const BigInt& y, const CurveParams* curve)
 bool ECPoint::is_on_curve() const {
     if (is_infinity_) return true;
     
-    // Verificar: yÂ² = xÂ³ + ax + b (mod p)
+    // Verificar: y^2 = x^3 + ax + b (mod p)
     ZZ_p::init(curve_->p);
     
     ZZ_p x_p = conv<ZZ_p>(x_);
@@ -216,16 +176,9 @@ bool ECPoint::is_on_curve() const {
 }
 
 bool ECPoint::operator==(const ECPoint& other) const {
-    // Verificar que estÃ¡n en la misma curva
     if (curve_ != other.curve_) return false;
-    
-    // Ambos infinito
     if (is_infinity_ && other.is_infinity_) return true;
-    
-    // Uno infinito, otro no
     if (is_infinity_ != other.is_infinity_) return false;
-    
-    // Comparar coordenadas
     return (x_ == other.x_) && (y_ == other.y_);
 }
 
@@ -240,34 +193,57 @@ void ECPoint::print() const {
 }
 
 // ============================================================================
-// OPERACIONES
+// JacobianPoint - IMPLEMENTACION
+// ============================================================================
+
+JacobianPoint::JacobianPoint(const CurveParams* curve)
+    : X_(to_ZZ(1)), Y_(to_ZZ(1)), Z_(to_ZZ(0)), curve_(curve) {
+    if (!curve_) {
+        throw std::invalid_argument("Curve parameters cannot be null");
+    }
+}
+
+JacobianPoint::JacobianPoint(const BigInt& X, const BigInt& Y, const BigInt& Z,
+                             const CurveParams* curve)
+    : X_(X), Y_(Y), Z_(Z), curve_(curve) {
+    if (!curve_) {
+        throw std::invalid_argument("Curve parameters cannot be null");
+    }
+}
+
+void JacobianPoint::print() const {
+    if (is_infinity()) {
+        std::cout << "Jacobian Point at infinity (Z=0)\n";
+    } else {
+        std::cout << "Jacobian Point on " << curve_->name << ":\n";
+        std::cout << "  X = " << X_ << "\n";
+        std::cout << "  Y = " << Y_ << "\n";
+        std::cout << "  Z = " << Z_ << "\n";
+    }
+}
+
+// ============================================================================
+// OPERACIONES AFINES
 // ============================================================================
 
 ECPoint ec_add(const ECPoint& P, const ECPoint& Q) {
-    // Verificar misma curva
     if (P.curve() != Q.curve()) {
         throw std::invalid_argument("Points must be on the same curve");
     }
     
     const CurveParams* curve = P.curve();
     
-    // Caso 1: P es infinito â†’ return Q
     if (P.is_infinity()) return Q;
-    
-    // Caso 2: Q es infinito â†’ return P
     if (Q.is_infinity()) return P;
     
-    // Caso 3: P = -Q â†’ return infinito
     if (P.x() == Q.x() && P.y() != Q.y()) {
-        return ECPoint(curve);  // Punto infinito
+        return ECPoint(curve);
     }
     
-    // Caso 4: P = Q â†’ duplicaciÃ³n
     if (P == Q) {
         return ec_double(P);
     }
     
-    // Caso 5: P â‰  Q, suma general
     ZZ_p::init(curve->p);
     
     ZZ_p x1 = conv<ZZ_p>(P.x());
@@ -275,13 +251,10 @@ ECPoint ec_add(const ECPoint& P, const ECPoint& Q) {
     ZZ_p x2 = conv<ZZ_p>(Q.x());
     ZZ_p y2 = conv<ZZ_p>(Q.y());
     
-    // Î» = (y2 - y1) / (x2 - x1)
+    // lambda = (y2 - y1) / (x2 - x1)  <-- division = inversion + multiplicacion
     ZZ_p lambda = (y2 - y1) / (x2 - x1);
     
-    // x3 = Î»Â² - x1 - x2
     ZZ_p x3 = power(lambda, 2) - x1 - x2;
-    
-    // y3 = Î»(x1 - x3) - y1
     ZZ_p y3 = lambda * (x1 - x3) - y1;
     
     return ECPoint(conv<BigInt>(x3), conv<BigInt>(y3), curve);
@@ -292,7 +265,6 @@ ECPoint ec_double(const ECPoint& P) {
     
     const CurveParams* curve = P.curve();
     
-    // Si y = 0, retornar infinito
     if (P.y() == 0) {
         return ECPoint(curve);
     }
@@ -303,13 +275,10 @@ ECPoint ec_double(const ECPoint& P) {
     ZZ_p y = conv<ZZ_p>(P.y());
     ZZ_p a = conv<ZZ_p>(curve->a);
     
-    // Î» = (3xÂ² + a) / (2y)
+    // lambda = (3x^2 + a) / (2y)  <-- otra inversion
     ZZ_p lambda = (3 * power(x, 2) + a) / (2 * y);
     
-    // x3 = Î»Â² - 2x
     ZZ_p x3 = power(lambda, 2) - 2 * x;
-    
-    // y3 = Î»(x - x3) - y
     ZZ_p y3 = lambda * (x - x3) - y;
     
     return ECPoint(conv<BigInt>(x3), conv<BigInt>(y3), curve);
@@ -319,8 +288,6 @@ ECPoint ec_negate(const ECPoint& P) {
     if (P.is_infinity()) return P;
     
     const CurveParams* curve = P.curve();
-    
-    // -P = (x, -y mod p)
     BigInt neg_y = (curve->p - P.y()) % curve->p;
     
     return ECPoint(P.x(), neg_y, curve);
@@ -328,18 +295,16 @@ ECPoint ec_negate(const ECPoint& P) {
 
 ECPoint ec_scalar_mult(const BigInt& k, const ECPoint& P) {
     if (k == 0 || P.is_infinity()) {
-        return ECPoint(P.curve());  // Infinito
+        return ECPoint(P.curve());
     }
     
     const CurveParams* curve = P.curve();
     
-    // Algoritmo double-and-add
-    ECPoint result(curve);  // Empieza en infinito
+    ECPoint result(curve);
     ECPoint addend = P;
     
-    BigInt k_copy = k % curve->n;  // Reducir mÃ³dulo n
+    BigInt k_copy = k % curve->n;
     
-    // Recorrer bits de k de derecha a izquierda
     while (k_copy > 0) {
         if (k_copy % 2 == 1) {
             result = ec_add(result, addend);
@@ -352,18 +317,237 @@ ECPoint ec_scalar_mult(const BigInt& k, const ECPoint& P) {
 }
 
 // ============================================================================
-// GENERACIÃ“N DE CLAVES
+// OPERACIONES EN COORDENADAS JACOBIANAS
 // ============================================================================
 
-ECKeyPair generate_keypair(const CurveParams& curve, RNG& rng) {
-    // 1. Generar clave privada: d âˆˆ [1, n-1]
+JacobianPoint to_jacobian(const ECPoint& P) {
+    if (P.is_infinity()) {
+        return JacobianPoint(P.curve());
+    }
+    // Conversion trivial: (x, y) -> (x, y, 1)
+    return JacobianPoint(P.x(), P.y(), to_ZZ(1), P.curve());
+}
+
+ECPoint to_affine(const JacobianPoint& J) {
+    if (J.is_infinity()) {
+        return ECPoint(J.curve());
+    }
+    
+    const CurveParams* curve = J.curve();
+    
+    // Esta es la UNICA inversion necesaria en toda la multiplicacion escalar
+    // x = X * Z^(-2), y = Y * Z^(-3)
+    ZZ_p::init(curve->p);
+    
+    ZZ_p Z_inv = inv(conv<ZZ_p>(J.Z()));
+    ZZ_p Z_inv2 = power(Z_inv, 2);    // Z^(-2)
+    ZZ_p Z_inv3 = Z_inv2 * Z_inv;     // Z^(-3)
+    
+    ZZ_p x = conv<ZZ_p>(J.X()) * Z_inv2;
+    ZZ_p y = conv<ZZ_p>(J.Y()) * Z_inv3;
+    
+    return ECPoint(conv<BigInt>(x), conv<BigInt>(y), curve);
+}
+
+/**
+ * Suma en coordenadas Jacobianas
+ * 
+ * Entrada: P1 = (X1, Y1, Z1), P2 = (X2, Y2, Z2)
+ * Salida:  P3 = (X3, Y3, Z3) = P1 + P2
+ * 
+ * Formulas (fuente: "Guide to Elliptic Curve Cryptography", Hankerson et al.):
+ *   U1 = X1 * Z2^2
+ *   U2 = X2 * Z1^2
+ *   S1 = Y1 * Z2^3
+ *   S2 = Y2 * Z1^3
+ *   H  = U2 - U1
+ *   R  = S2 - S1
+ * 
+ *   Si H == 0 y R == 0: es doblado (P1 == P2)
+ *   Si H == 0 y R != 0: resultado es infinito (P1 == -P2)
+ * 
+ *   X3 = R^2 - H^3 - 2*U1*H^2
+ *   Y3 = R*(U1*H^2 - X3) - S1*H^3
+ *   Z3 = H * Z1 * Z2
+ * 
+ * Coste total: 12M + 4S (0 inversiones)
+ */
+JacobianPoint jacobian_add(const JacobianPoint& P, const JacobianPoint& Q) {
+    if (P.curve() != Q.curve()) {
+        throw std::invalid_argument("Points must be on the same curve");
+    }
+    
+    const CurveParams* curve = P.curve();
+    
+    // Casos triviales
+    if (P.is_infinity()) return Q;
+    if (Q.is_infinity()) return P;
+    
+    ZZ_p::init(curve->p);
+    
+    ZZ_p X1 = conv<ZZ_p>(P.X());
+    ZZ_p Y1 = conv<ZZ_p>(P.Y());
+    ZZ_p Z1 = conv<ZZ_p>(P.Z());
+    ZZ_p X2 = conv<ZZ_p>(Q.X());
+    ZZ_p Y2 = conv<ZZ_p>(Q.Y());
+    ZZ_p Z2 = conv<ZZ_p>(Q.Z());
+    
+    ZZ_p Z1_sq = sqr(Z1);       // Z1^2
+    ZZ_p Z2_sq = sqr(Z2);       // Z2^2
+    
+    ZZ_p U1 = X1 * Z2_sq;       // U1 = X1 * Z2^2
+    ZZ_p U2 = X2 * Z1_sq;       // U2 = X2 * Z1^2
+    ZZ_p S1 = Y1 * Z2_sq * Z2;  // S1 = Y1 * Z2^3
+    ZZ_p S2 = Y2 * Z1_sq * Z1;  // S2 = Y2 * Z1^3
+    
+    ZZ_p H = U2 - U1;           // H = U2 - U1
+    ZZ_p R = S2 - S1;           // R = S2 - S1
+    
+    // Comprobar casos especiales
+    if (IsZero(H)) {
+        if (IsZero(R)) {
+            // P == Q: usar doblado
+            return jacobian_double(P);
+        }
+        // P == -Q: resultado es infinito
+        return JacobianPoint(curve);
+    }
+    
+    ZZ_p H_sq = sqr(H);         // H^2
+    ZZ_p H_cu = H_sq * H;       // H^3
+    ZZ_p U1H2 = U1 * H_sq;     // U1 * H^2
+    
+    // X3 = R^2 - H^3 - 2*U1*H^2
+    ZZ_p X3 = sqr(R) - H_cu - 2 * U1H2;
+    
+    // Y3 = R*(U1*H^2 - X3) - S1*H^3
+    ZZ_p Y3 = R * (U1H2 - X3) - S1 * H_cu;
+    
+    // Z3 = H * Z1 * Z2
+    ZZ_p Z3 = H * Z1 * Z2;
+    
+    return JacobianPoint(conv<BigInt>(X3), conv<BigInt>(Y3), 
+                         conv<BigInt>(Z3), curve);
+}
+
+/**
+ * Doblado en coordenadas Jacobianas
+ * 
+ * Entrada: P = (X1, Y1, Z1)
+ * Salida:  2P = (X3, Y3, Z3)
+ * 
+ * Formulas:
+ *   A = Y1^2
+ *   B = 4 * X1 * A
+ *   C = 8 * A^2
+ *   D = 3 * X1^2 + a * Z1^4
+ *   X3 = D^2 - 2*B
+ *   Y3 = D*(B - X3) - C
+ *   Z3 = 2 * Y1 * Z1
+ * 
+ * Coste total: 4M + 4S (0 inversiones)
+ * 
+ * Nota: para secp256k1 donde a=0, D se simplifica a 3*X1^2 (ahorro extra).
+ * Para NIST P-256 donde a=-3, D = 3*(X1-Z1^2)*(X1+Z1^2) (optimizable).
+ */
+JacobianPoint jacobian_double(const JacobianPoint& P) {
+    if (P.is_infinity()) return P;
+    
+    const CurveParams* curve = P.curve();
+    
+    ZZ_p::init(curve->p);
+    
+    ZZ_p X1 = conv<ZZ_p>(P.X());
+    ZZ_p Y1 = conv<ZZ_p>(P.Y());
+    ZZ_p Z1 = conv<ZZ_p>(P.Z());
+    
+    // Si Y1 = 0, resultado es infinito (tangente vertical)
+    if (IsZero(Y1)) {
+        return JacobianPoint(curve);
+    }
+    
+    ZZ_p a_p = conv<ZZ_p>(curve->a);
+    
+    ZZ_p A = sqr(Y1);                  // A = Y1^2
+    ZZ_p B = 4 * X1 * A;              // B = 4*X1*A
+    ZZ_p C = 8 * sqr(A);              // C = 8*A^2
+    
+    // D = 3*X1^2 + a*Z1^4
+    ZZ_p Z1_sq = sqr(Z1);
+    ZZ_p D = 3 * sqr(X1) + a_p * sqr(Z1_sq);
+    
+    // X3 = D^2 - 2*B
+    ZZ_p X3 = sqr(D) - 2 * B;
+    
+    // Y3 = D*(B - X3) - C
+    ZZ_p Y3 = D * (B - X3) - C;
+    
+    // Z3 = 2*Y1*Z1
+    ZZ_p Z3 = 2 * Y1 * Z1;
+    
+    return JacobianPoint(conv<BigInt>(X3), conv<BigInt>(Y3),
+                         conv<BigInt>(Z3), curve);
+}
+
+/**
+ * Multiplicacion escalar usando coordenadas Jacobianas
+ * 
+ * Flujo:
+ * 1. Convertir punto afin P a Jacobiano J = (Px, Py, 1)
+ * 2. Ejecutar double-and-add enteramente en Jacobianas
+ * 3. Convertir resultado final a afin (UNA sola inversion)
+ * 
+ * Para k de 256 bits:
+ * - ~256 doblados Jacobianos (4M + 4S cada uno)
+ * - ~128 sumas Jacobianas (12M + 4S cada una)
+ * - 1 inversion final
+ * Total: ~2560M + ~1536S + 1I
+ * 
+ * Comparado con afin:
+ * - ~256 doblados (1I + 2M + 2S) + ~128 sumas (1I + 2M + 1S)
+ * Total: ~384I + ~768M + ~640S
+ * Con I ~ 80M: ~31,488M equivalentes (afin) vs ~4,096M (Jacobiano)
+ * Factor teorico: ~7.7x mas rapido (en practica 3-5x por overheads)
+ */
+ECPoint ec_scalar_mult_jacobian(const BigInt& k, const ECPoint& P) {
+    if (k == 0 || P.is_infinity()) {
+        return ECPoint(P.curve());
+    }
+    
+    const CurveParams* curve = P.curve();
+    
+    // Paso 1: Convertir a Jacobiano
+    JacobianPoint result(curve);  // Infinito
+    JacobianPoint addend = to_jacobian(P);
+    
+    BigInt k_copy = k % curve->n;
+    
+    // Paso 2: Double-and-add en Jacobiano (sin inversiones)
+    while (k_copy > 0) {
+        if (k_copy % 2 == 1) {
+            result = jacobian_add(result, addend);
+        }
+        addend = jacobian_double(addend);
+        k_copy /= 2;
+    }
+    
+    // Paso 3: Convertir resultado a afin (UNA inversion)
+    return to_affine(result);
+}
+
+// ============================================================================
+// GENERACION DE CLAVES
+// ============================================================================
+
+ECKeyPair generate_keypair(const CurveParams& curve, RNG& rng,
+                           bool use_jacobian) {
     BigInt private_key = rng.random_range(to_ZZ(1), curve.n - 1);
     
-    // 2. Calcular clave pÃºblica: Q = d*G
     ECPoint G(curve.Gx, curve.Gy, &curve);
-    ECPoint public_key = ec_scalar_mult(private_key, G);
+    ECPoint public_key = use_jacobian 
+        ? ec_scalar_mult_jacobian(private_key, G)
+        : ec_scalar_mult(private_key, G);
     
-    // 3. Retornar usando brace initialization (aggregate initialization)
     return ECKeyPair{private_key, public_key, &curve};
 }
 
@@ -379,7 +563,7 @@ void ECKeyPair::print(bool show_private) const {
         std::cout << "Clave privada: [OCULTA]\n";
     }
     
-    std::cout << "\nClave pÃºblica (Q):\n";
+    std::cout << "\nClave publica (Q):\n";
     public_key.print();
     std::cout << std::string(70, '=') << "\n";
 }
@@ -389,9 +573,11 @@ void ECKeyPair::print(bool show_private) const {
 // ============================================================================
 
 ECPoint ecdh_shared_secret(const BigInt& private_key, 
-                           const ECPoint& public_key) {
-    // S = private_key * public_key
-    return ec_scalar_mult(private_key, public_key);
+                           const ECPoint& public_key,
+                           bool use_jacobian) {
+    return use_jacobian
+        ? ec_scalar_mult_jacobian(private_key, public_key)
+        : ec_scalar_mult(private_key, public_key);
 }
 
 BigInt ecdh_derive_key(const ECPoint& shared_point, int key_bits) {
@@ -399,14 +585,9 @@ BigInt ecdh_derive_key(const ECPoint& shared_point, int key_bits) {
         throw std::runtime_error("Cannot derive key from point at infinity");
     }
     
-    // DerivaciÃ³n simple: usar coordenada x como clave
-    // En producciÃ³n: usar KDF como HKDF o PBKDF2
-    
-    // Tomar solo los bits necesarios
     BigInt key = shared_point.x();
     
     if (key_bits < NumBits(key)) {
-        // Truncar a los bits necesarios
         key = key % power2_ZZ(key_bits);
     }
     
@@ -414,7 +595,7 @@ BigInt ecdh_derive_key(const ECPoint& shared_point, int key_bits) {
 }
 
 // ============================================================================
-// ECDSA - FIRMA DIGITAL (FIPS 186-4)
+// ECDSA - FIRMA DIGITAL
 // ============================================================================
 
 bool ECDSASignature::is_valid_format(const BigInt& n) const {
@@ -428,12 +609,10 @@ void ECDSASignature::print() const {
 }
 
 BigInt truncate_hash(const BigInt& hash, const BigInt& n) {
-    // Si el hash tiene más bits que n, truncar los más significativos
     long n_bits = NumBits(n);
     long hash_bits = NumBits(hash);
     
     if (hash_bits > n_bits) {
-        // Desplazar a la derecha para truncar
         return hash >> (hash_bits - n_bits);
     }
     
@@ -443,41 +622,33 @@ BigInt truncate_hash(const BigInt& hash, const BigInt& n) {
 ECDSASignature ecdsa_sign_hash(const BigInt& hash_value,
                                const BigInt& private_key,
                                const CurveParams& curve,
-                               RNG& rng) {
-    // Validar clave privada
+                               RNG& rng,
+                               bool use_jacobian) {
     if (private_key <= 0 || private_key >= curve.n) {
         throw std::invalid_argument("Private key must be in range [1, n-1]");
     }
     
-    // Punto generador
     ECPoint G(curve.Gx, curve.Gy, &curve);
-    
-    // Truncar hash al tamaño del orden de la curva
     BigInt z = truncate_hash(hash_value, curve.n);
     
     ECDSASignature sig;
     
-    // Bucle hasta encontrar firma valida (r != 0 && s != 0)
     while (true) {
-        // 1. Seleccionar k aleatorio en [1, n-1]
         BigInt k = rng.random_range(to_ZZ(1), curve.n - 1);
         
-        // 2. Calcular (x1, y1) = k * G
-        ECPoint kG = ec_scalar_mult(k, G);
+        ECPoint kG = use_jacobian
+            ? ec_scalar_mult_jacobian(k, G)
+            : ec_scalar_mult(k, G);
         
         if (kG.is_infinity()) continue;
         
-        // 3. r = x1 mod n
         sig.r = kG.x() % curve.n;
         if (sig.r == 0) continue;
         
-        // 4. s = k⁻¹ · (z + r·d) mod n
         BigInt k_inv = InvMod(k, curve.n);
         sig.s = (k_inv * ((z + sig.r * private_key) % curve.n)) % curve.n;
         
         if (sig.s == 0) continue;
-        
-        // Firma valida encontrada
         break;
     }
     
@@ -487,67 +658,45 @@ ECDSASignature ecdsa_sign_hash(const BigInt& hash_value,
 ECDSASignature ecdsa_sign(const std::string& message,
                           const BigInt& private_key,
                           const CurveParams& curve,
-                          RNG& rng) {
-    // 1. Calcular hash SHA-256 del mensaje
+                          RNG& rng,
+                          bool use_jacobian) {
     BigInt hash_value = SHA256::hash_to_bigint(message);
-    
-    // 2. Firmar el hash
-    return ecdsa_sign_hash(hash_value, private_key, curve, rng);
+    return ecdsa_sign_hash(hash_value, private_key, curve, rng, use_jacobian);
 }
 
 bool ecdsa_verify_hash(const BigInt& hash_value,
                        const ECDSASignature& signature,
                        const ECPoint& public_key,
-                       const CurveParams& curve) {
-    // 1. Verificar formato de la firma
-    if (!signature.is_valid_format(curve.n)) {
-        return false;
-    }
+                       const CurveParams& curve,
+                       bool use_jacobian) {
+    if (!signature.is_valid_format(curve.n)) return false;
+    if (public_key.is_infinity() || !public_key.is_on_curve()) return false;
     
-    // 2. Verificar que la clave pública está en la curva y no es infinito
-    if (public_key.is_infinity() || !public_key.is_on_curve()) {
-        return false;
-    }
-    
-    // 3. Truncar hash al tamaño del orden
     BigInt z = truncate_hash(hash_value, curve.n);
-    
-    // 4. w = s⁻¹ mod n
     BigInt w = InvMod(signature.s, curve.n);
-    
-    // 5. u1 = z·w mod n
     BigInt u1 = (z * w) % curve.n;
-    
-    // 6. u2 = r·w mod n
     BigInt u2 = (signature.r * w) % curve.n;
     
-    // 7. (x1, y1) = u1·G + u2·Q
     ECPoint G(curve.Gx, curve.Gy, &curve);
     
-    ECPoint u1G = ec_scalar_mult(u1, G);
-    ECPoint u2Q = ec_scalar_mult(u2, public_key);
+    ECPoint u1G = use_jacobian ? ec_scalar_mult_jacobian(u1, G) : ec_scalar_mult(u1, G);
+    ECPoint u2Q = use_jacobian ? ec_scalar_mult_jacobian(u2, public_key) : ec_scalar_mult(u2, public_key);
+    
     ECPoint point = ec_add(u1G, u2Q);
     
-    // 8. Si el punto resultante es infinito, firma invalida
-    if (point.is_infinity()) {
-        return false;
-    }
+    if (point.is_infinity()) return false;
     
-    // 9. Firma valida si r ≡ x1 (mod n)
     BigInt v = point.x() % curve.n;
-    
     return v == signature.r;
 }
 
 bool ecdsa_verify(const std::string& message,
                   const ECDSASignature& signature,
                   const ECPoint& public_key,
-                  const CurveParams& curve) {
-    // 1. Calcular hash SHA-256 del mensaje
+                  const CurveParams& curve,
+                  bool use_jacobian) {
     BigInt hash_value = SHA256::hash_to_bigint(message);
-    
-    // 2. Verificar la firma
-    return ecdsa_verify_hash(hash_value, signature, public_key, curve);
+    return ecdsa_verify_hash(hash_value, signature, public_key, curve, use_jacobian);
 }
 
 // ============================================================================
@@ -565,27 +714,18 @@ std::string curve_type_to_string(CurveType type) {
 }
 
 int ecc_to_rsa_security(int curve_bits) {
-    // Mapeo de seguridad ECC â†’ RSA
-    // Fuente: NIST SP 800-57
-    
-    if (curve_bits <= 160) return 1024;   // DÃ©bil
-    if (curve_bits <= 224) return 2048;   // MÃ­nimo actual
-    if (curve_bits <= 256) return 3072;   // EstÃ¡ndar
-    if (curve_bits <= 384) return 7680;   // Alta seguridad
-    if (curve_bits <= 521) return 15360;  // Muy alta
-    
-    return 15360;  // MÃ¡ximo
+    if (curve_bits <= 160) return 1024;
+    if (curve_bits <= 224) return 2048;
+    if (curve_bits <= 256) return 3072;
+    if (curve_bits <= 384) return 7680;
+    if (curve_bits <= 521) return 15360;
+    return 15360;
 }
 
 CurveType rsa_to_ecc_curve(int rsa_bits) {
-    // Mapeo RSA â†’ Curva ECC recomendada
-    
-    if (rsa_bits <= 1024) return CurveType::NIST_P256;  // MÃ­nimo
-    if (rsa_bits <= 2048) return CurveType::NIST_P256;
     if (rsa_bits <= 3072) return CurveType::NIST_P256;
     if (rsa_bits <= 4096) return CurveType::NIST_P384;
-    
-    return CurveType::NIST_P384;  // MÃ¡ximo soportado
+    return CurveType::NIST_P384;
 }
 
 } // namespace crypto


### PR DESCRIPTION
**ecc.hpp / ecc.cpp**:
- Nueva clase `JacobianPoint` con `(X, Y, Z)` y documentacion exhaustiva sobre por que existe cada representacion
- `jacobian_add()` y `jacobian_double()` con las formulas completas comentadas (coste en multiplicaciones)
- `ec_scalar_mult_jacobian()` que hace todo el double-and-add en Jacobiano y solo convierte a afin al final (1 inversion vs ~384)
- Parametro `use_jacobian` anhadido a `generate_keypair`, `ecdsa_sign`, `ecdsa_verify` y `ecdh_shared_secret` para poder comparar ambos modos
- Todo retrocompatible: sin el flag, usa afines como antes